### PR TITLE
Update manifest.json to allow extension to run on gamepad-tester.com

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,7 +6,7 @@ chrome.runtime.onInstalled.addListener(function() {
                     pageUrl: {hostEquals: "stadia.google.com"},
                 }),
                 new chrome.declarativeContent.PageStateMatcher({
-                    pageUrl: {hostEquals: "html5gamepad.com"},
+                    pageUrl: {hostEquals: "gamepad-tester.com"},
                 }),
             ],
             actions: [new chrome.declarativeContent.ShowPageAction()]

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
 		{
 			"matches": [
 				"https://stadia.google.com/*",
-				"https://html5gamepad.com/*"
+				"https://gamepad-tester.com/*"
 			],
 			"js": ["controlstadia.js"],
 			"run_at": "document_start"


### PR DESCRIPTION
html5gamepad.com redirects to gamepad-tester.com. This update allows the extension to run on gamepad-tester.com and allows for visual feedback during controller configuration.