### PR TITLE
Add deadzone to axis value change detection during control binding

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -109,7 +109,8 @@ const awaitInputToSet = function(srcType, srcIndex, buttonLabelElem){
             }
         }
         for(let i = 0; i < originalAxesState.length; i++){
-            if(currentAxesState[i] !== originalAxesState[i]){
+            if(currentAxesState[i] >= originalAxesState[i] + 0.5 ||
+                currentAxesState[i] <= originalAxesState[i] - 0.5){
                 changeFound(1, i);
                 clearInterval(checkInterval);
                 break;


### PR DESCRIPTION
Fix control binding for controllers with an unfiltered axis position output value. Even if there's some change in the axis value during the binding of a control, ControlStadia won't assign that axis mistakenly to the control being changed, only when the value is larger than the deadzone of +-0.5.

Ps Thanks for the extension, this was the only way to make a cheap xbox-like controller work with Stadia on Ubuntu 20.04 and 20.10.